### PR TITLE
Omit attributes when the value is an empty list or contains only nils

### DIFF
--- a/lib/phlex/sgml/attributes.rb
+++ b/lib/phlex/sgml/attributes.rb
@@ -135,9 +135,13 @@ module Phlex::SGML::Attributes
 			when Hash
 				generate_nested_attributes(v, "#{base_name}#{name}-", buffer)
 			when Array
-				buffer << " " << base_name << name << '="' << generate_nested_tokens(v) << '"'
+				if (value = generate_nested_tokens(v))
+					buffer << " " << base_name << name << '="' << value << '"'
+				end
 			when Set
-				buffer << " " << base_name << name << '="' << generate_nested_tokens(v.to_a) << '"'
+				if (value = generate_nested_tokens(v.to_a))
+					buffer << " " << base_name << name << '="' << value << '"'
+				end
 			when Phlex::SGML::SafeObject
 				buffer << " " << base_name << name << '="' << v.to_s.gsub('"', "&quot;") << '"'
 			else
@@ -181,11 +185,19 @@ module Phlex::SGML::Attributes
 					buffer << token.to_s
 				end
 			when Array
-				if token.length > 0
+				if token.length > 0 && (value = generate_nested_tokens(token, sep, gsub_from, gsub_to))
 					if i > 0
-						buffer << sep << generate_nested_tokens(token, sep, gsub_from, gsub_to)
+						buffer << sep << value
 					else
-						buffer << generate_nested_tokens(token, sep, gsub_from, gsub_to)
+						buffer << value
+					end
+				end
+			when Set
+				if token.length > 0 && (value = generate_nested_tokens(token.to_a, sep, gsub_from, gsub_to))
+					if i > 0
+						buffer << sep << value
+					else
+						buffer << value
 					end
 				end
 			when nil
@@ -196,6 +208,8 @@ module Phlex::SGML::Attributes
 
 			i += 1
 		end
+
+		return if buffer.empty?
 
 		buffer.gsub('"', "&quot;")
 	end

--- a/quickdraw/sgml/attributes.test.rb
+++ b/quickdraw/sgml/attributes.test.rb
@@ -194,12 +194,27 @@ end
 
 test "_, Array" do
 	output = phlex { div(attribute: []) }
-	assert_equal_html output, %(<div attribute=""></div>)
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Array(Array)" do
+	output = phlex { div(attribute: [[], [], []]) }
+	assert_equal_html output, %(<div></div>)
 end
 
 test "_, Array(nil)" do
 	output = phlex { div(attribute: [nil, nil, nil]) }
-	assert_equal_html output, %(<div attribute=""></div>)
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Array(Array(nil))" do
+	output = phlex { div(attribute: [[nil, nil], [nil, nil]]) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Array(Array(nil), nil)" do
+	output = phlex { div(attribute: [[nil, nil], nil]) }
+	assert_equal_html output, %(<div></div>)
 end
 
 test "_, Array(String)" do
@@ -371,6 +386,11 @@ test "_, Hash(_, Hash)" do
 	assert_equal_html output, %(<div data-controller-hello="world"></div>)
 end
 
+test "_, Hash(_, Hash(_, nil)" do
+	output = phlex { div(data: { controller: { hello: nil } }) }
+	assert_equal_html output, %(<div></div>)
+end
+
 test "_, Hash(_, Phlex::SGML::SafeObject)" do
 	output = phlex { div(data: { controller: Phlex::SGML::SafeValue.new("Hello") }) }
 	assert_equal_html output, %(<div data-controller="Hello"></div>)
@@ -386,15 +406,70 @@ test "_, Hash(_, nil)" do
 	assert_equal_html output, %(<div></div>)
 end
 
+test "_, Hash(_, Array)" do
+	output = phlex { div(data: { action: [] }) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Hash(_, Array(nil))" do
+	output = phlex { div(data: { action: [nil] }) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Hash(_, Set)" do
+	output = phlex { div(data: { action: Set[] }) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Hash(_, Set(Set))" do
+	output = phlex { div(data: { action: Set[Set[]] }) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Hash(_, Set(nil))" do
+	output = phlex { div(data: { action: Set[nil] }) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Hash(_, Set(Set(nil)))" do
+	output = phlex { div(data: { action: Set[Set[nil]] }) }
+	assert_equal_html output, %(<div></div>)
+end
+
 test "_, Hash(_, *invalid*)" do
 	assert_raises(Phlex::ArgumentError) do
 		phlex { div(data: { controller: Object.new }) }
 	end
 end
 
+test "_, Set" do
+	output = phlex { div(attribute: Set[]) }
+	assert_equal_html output, %(<div></div>)
+end
+
 test "_, Set(nil)" do
 	output = phlex { div(attribute: Set[nil, nil, nil]) }
-	assert_equal_html output, %(<div attribute=""></div>)
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Set(Set)" do
+	output = phlex { div(attribute: Set[Set[]]) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Set(Set(nil))" do
+	output = phlex { div(attribute: Set[Set[nil, nil, nil]]) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Set(Set, nil)" do
+	output = phlex { div(attribute: Set[Set[], nil]) }
+	assert_equal_html output, %(<div></div>)
+end
+
+test "_, Set(Set(nil), nil)" do
+	output = phlex { div(attribute: Set[Set[nil], nil]) }
+	assert_equal_html output, %(<div></div>)
 end
 
 test "_, Set(String)" do
@@ -540,7 +615,7 @@ end
 
 test ":srcset on img with an Array" do
 	output = phlex { img(srcset: []) }
-	assert_equal_html output, %(<img srcset="">)
+	assert_equal_html output, %(<img>)
 
 	output = phlex { img(srcset: ["/width=400/image.jpg 1x", "/width=400,dpr=2/image.jpg 2x"]) }
 	assert_equal_html output, %(<img srcset="/width=400/image.jpg 1x, /width=400%2Cdpr=2/image.jpg 2x">)
@@ -551,7 +626,7 @@ end
 
 test ":media on link with an Array" do
 	output = phlex { link(media: []) }
-	assert_equal_html output, %(<link media="">)
+	assert_equal_html output, %(<link>)
 
 	output = phlex { link(media: ["screen", "print"]) }
 	assert_equal_html output, %(<link media="screen, print">)
@@ -562,7 +637,7 @@ end
 
 test ":sizes on link with an Array" do
 	output = phlex { link(sizes: []) }
-	assert_equal_html output, %(<link sizes="">)
+	assert_equal_html output, %(<link>)
 
 	output = phlex { link(sizes: ["16x16", "32x32", "64x64"]) }
 	assert_equal_html output, %(<link sizes="16x16, 32x32, 64x64">)
@@ -570,7 +645,7 @@ end
 
 test ":imagesrcset on link with an Array when rel is preload and as is image" do
 	output = phlex { link(imagesrcset: [], rel: "preload", as: "image") }
-	assert_equal_html output, %(<link imagesrcset="" rel="preload" as="image">)
+	assert_equal_html output, %(<link rel="preload" as="image">)
 
 	output = phlex { link(imagesrcset: ["image.jpg 1x", "image@2x.jpg 2x"], rel: "preload", as: "image") }
 	assert_equal_html output, %(<link imagesrcset="image.jpg 1x, image@2x.jpg 2x" rel="preload" as="image">)
@@ -584,7 +659,7 @@ end
 
 test ":accept on input with array when type is file" do
 	output = phlex { input(accept: [], type: "file") }
-	assert_equal_html output, %(<input accept="" type="file">)
+	assert_equal_html output, %(<input type="file">)
 
 	output = phlex { input(accept: ["image/jpeg", "image/png"], type: "file") }
 	assert_equal_html output, %(<input accept="image/jpeg, image/png" type="file">)


### PR DESCRIPTION
Implements #909. I haven't benchmarked this but I'm hopeful about it. Because `__attributes__` implicitly discards nil via the `case value` statement, we just have to make `__nested_tokens__` resolve to nil, which is accomplished by returning early on an empty buffer. We can handle nested arrays and sets, as well as nested attributes, by checking for that nil return value in places where we call `__nested_tokens__`.