### PR TITLE
Add comma escaping in values of comma-separated lists

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -608,7 +608,7 @@ class Phlex::SGML
 		end
 	end
 
-	private def __nested_tokens__(tokens, sep = " ")
+	private def __nested_tokens__(tokens, sep = " ", gsub_from = nil, gsub_to	= "")
 		buffer = +""
 
 		i, length = 0, tokens.length
@@ -618,6 +618,7 @@ class Phlex::SGML
 
 			case token
 			when String
+				token = token.gsub(gsub_from, gsub_to) if gsub_from
 				if i > 0
 					buffer << sep << token
 				else
@@ -638,9 +639,9 @@ class Phlex::SGML
 			when Array
 				if token.length > 0
 					if i > 0
-						buffer << sep << __nested_tokens__(token, sep)
+						buffer << sep << __nested_tokens__(token, sep, gsub_from, gsub_to)
 					else
-						buffer << __nested_tokens__(token, sep)
+						buffer << __nested_tokens__(token, sep, gsub_from, gsub_to)
 					end
 				end
 			when nil

--- a/lib/phlex/sgml/elements.rb
+++ b/lib/phlex/sgml/elements.rb
@@ -4,16 +4,16 @@ module Phlex::SGML::Elements
 	COMMA_SEPARATED_TOKENS = {
 		img: <<~RUBY,
 			if Array === (srcset_attribute = attributes[:srcset])
-				attributes[:srcset] = __nested_tokens__(srcset_attribute, ", ")
+				attributes[:srcset] = __nested_tokens__(srcset_attribute, ", ", ",", "%2C")
 			end
 		RUBY
 		link: <<~RUBY,
 			if Array === (media_attribute = attributes[:media])
-				attributes[:media] = __nested_tokens__(media_attribute, ", ")
+				attributes[:media] = __nested_tokens__(media_attribute, ", ", ",", "%2C")
 			end
 
 			if Array === (sizes_attribute = attributes[:sizes])
-				attributes[:sizes] = __nested_tokens__(sizes_attribute, ", ")
+				attributes[:sizes] = __nested_tokens__(sizes_attribute, ", ", ",", "%2C")
 			end
 
 			if Array === (imagesrcset_attribute = attributes[:imagesrcset])
@@ -21,7 +21,7 @@ module Phlex::SGML::Elements
 				as_attribute = attributes[:as] || attributes["as"]
 
 				if ("preload" == rel_attribute || :preload == rel_attribute) && ("image" == as_attribute || :image == as_attribute)
-					attributes[:imagesrcset] = __nested_tokens__(imagesrcset_attribute, ", ")
+					attributes[:imagesrcset] = __nested_tokens__(imagesrcset_attribute, ", ", ",", "%2C")
 				end
 			end
 		RUBY
@@ -30,7 +30,7 @@ module Phlex::SGML::Elements
 				type_attribute = attributes[:type] || attributes["type"]
 
 				if "file" == type_attribute || :file == type_attribute
-					attributes[:accept] = __nested_tokens__(accept_attribute, ", ")
+					attributes[:accept] = __nested_tokens__(accept_attribute, ", ", ",", "%2C")
 				end
 			end
 		RUBY

--- a/quickdraw/sgml/attributes.test.rb
+++ b/quickdraw/sgml/attributes.test.rb
@@ -542,8 +542,11 @@ test ":srcset on img with an Array" do
 	output = phlex { img(srcset: []) }
 	assert_equal_html output, %(<img srcset="">)
 
-	output = phlex { img(srcset: ["image.jpg 1x", "image@2x.jpg 2x"]) }
-	assert_equal_html output, %(<img srcset="image.jpg 1x, image@2x.jpg 2x">)
+	output = phlex { img(srcset: ["/width=400/image.jpg 1x", "/width=400,dpr=2/image.jpg 2x"]) }
+	assert_equal_html output, %(<img srcset="/width=400/image.jpg 1x, /width=400%2Cdpr=2/image.jpg 2x">)
+
+	output = phlex { img(srcset: ["/width=400/image.jpg 1x", ["/width=400,dpr=2/image.jpg 2x"]]) }
+	assert_equal_html output, %(<img srcset="/width=400/image.jpg 1x, /width=400%2Cdpr=2/image.jpg 2x">)
 end
 
 test ":media on link with an Array" do
@@ -575,8 +578,8 @@ test ":imagesrcset on link with an Array when rel is preload and as is image" do
 	output = phlex { link(imagesrcset: ["image.jpg 1x", "image@2x.jpg 2x"], rel: :preload, as: :image) }
 	assert_equal_html output, %(<link imagesrcset="image.jpg 1x, image@2x.jpg 2x" rel="preload" as="image">)
 
-	output = phlex { link(:imagesrcset => ["image.jpg 1x", "image@2x.jpg 2x"], "rel" => "preload", "as" => "image") }
-	assert_equal_html output, %(<link imagesrcset="image.jpg 1x, image@2x.jpg 2x" rel="preload" as="image">)
+	output = phlex { link(:imagesrcset => ["/width=400/image.jpg 1x", "/width=400,dpr=2/image@2x.jpg 2x"], "rel" => "preload", "as" => "image") }
+	assert_equal_html output, %(<link imagesrcset="/width=400/image.jpg 1x, /width=400%2Cdpr=2/image@2x.jpg 2x" rel="preload" as="image">)
 end
 
 test ":accept on input with array when type is file" do


### PR DESCRIPTION
Fixes #912

I ended up going with additional arguments to `__nested_tokens__` to define the transform. I started by using an array of arrays to represent arbitrarily many substitutions, but as of right now I think we only need one substitution. And I was trying to avoid array allocations, so I just flattened them into the argument list.

I wish there was a cleaner way to avoid that conditional on each iteration of the `tokens` array.

I also opted not to escape the values if symbols are used. Mainly for keeping the symbol branch free of some extra operations, when I think it's highly unlikely someone would use symbols for this. So I'll look forward to that issue 😄 

Feedback welcome!