### PR TITLE
Support selective rendering in compiled components

### DIFF
--- a/lib/phlex/compiler/method_compiler.rb
+++ b/lib/phlex/compiler/method_compiler.rb
@@ -188,7 +188,7 @@ module Phlex::Compiler
 				body: [
 					statement("__phlex_original_should_render__ = __phlex_should_render__"),
 					statement("__phlex_should_render__ = __phlex_state__.should_render?;"),
-					compile_block_body_node(node.body),
+					visit(node.body),
 					statement("__phlex_should_render__ = __phlex_original_should_render__"),
 				]
 			)

--- a/lib/phlex/compiler/method_compiler.rb
+++ b/lib/phlex/compiler/method_compiler.rb
@@ -14,10 +14,16 @@ module Phlex::Compiler
 			result.body&.body&.unshift(
 				proc do |f|
 					f.statement do
-						f.push "__phlex_buffer__ = @_state.buffer; nil"
+						f.push "__phlex_state__ = @_state"
 					end
 					f.statement do
-						f.push "__phlex_me__ = self; nil"
+						f.push "__phlex_buffer__ = __phlex_state__.buffer"
+					end
+					f.statement do
+						f.push "__phlex_me__ = self"
+					end
+					f.statement do
+						f.push "__phlex_should_render__ = __phlex_state__.should_render?; nil"
 					end
 				end
 			)
@@ -38,6 +44,8 @@ module Phlex::Compiler
 					return compile_doctype_helper(node)
 				elsif plain_helper?(node)
 					return compile_plain_helper(node)
+				elsif fragment_helper?(node)
+					return compile_fragment_helper(node)
 				end
 			end
 
@@ -110,14 +118,18 @@ module Phlex::Compiler
 
 		def visit_block_node(node)
 			node.copy(
-				body: [
-					statement("if __phlex_me__ == self"),
-					visit(node.body),
-					statement("else"),
-					[[node.body]],
-					statement("end"),
-				]
+				body: compile_block_body_node(node.body)
 			)
+		end
+
+		def compile_block_body_node(node)
+			[
+				statement("if __phlex_me__ == self;"),
+				visit(node),
+				statement("else;"),
+				[[node]],
+				statement("end;"),
+			]
 		end
 
 		def compile_void_element(node, tag)
@@ -165,6 +177,23 @@ module Phlex::Compiler
 			end
 		end
 
+		def compile_fragment_helper(node)
+			node.copy(
+				block: compile_fragment_helper_block(node.block)
+			)
+		end
+
+		def compile_fragment_helper_block(node)
+			node.copy(
+				body: [
+					statement("__phlex_original_should_render__ = __phlex_should_render__"),
+					statement("__phlex_should_render__ = __phlex_state__.should_render?;"),
+					compile_block_body_node(node.body),
+					statement("__phlex_should_render__ = __phlex_original_should_render__"),
+				]
+			)
+		end
+
 		private def ensure_new_line
 			proc(&:ensure_new_line)
 		end
@@ -204,7 +233,7 @@ module Phlex::Compiler
 
 				proc do |f|
 					f.statement do
-						f.push "__phlex_buffer__ << \"#{new_buffer.gsub('"', '\\"')}\"; nil"
+						f.push "__phlex_buffer__ << \"#{new_buffer.gsub('"', '\\"')}\" if __phlex_should_render__; nil;"
 					end
 				end
 			end
@@ -258,6 +287,10 @@ module Phlex::Compiler
 
 		private def plain_helper?(node)
 			node.name == :plain && own_method_without_scope?(node)
+		end
+
+		private def fragment_helper?(node)
+			node.name == :fragment && own_method_without_scope?(node)
 		end
 
 		ALLOWED_OWNERS = [Phlex::SGML, Phlex::HTML, Phlex::SVG]

--- a/lib/phlex/compiler/verbatim_formatter.rb
+++ b/lib/phlex/compiler/verbatim_formatter.rb
@@ -22,6 +22,7 @@ module Phlex::Compiler
 		end
 
 		def emit(node)
+			return unless node
 			source_map = @source_map
 			current_line = @current_line
 			start_line = node.start_line
@@ -33,7 +34,7 @@ module Phlex::Compiler
 				i += 1
 			end
 
-			push node.slice if node
+			push node.slice
 		end
 
 		def visit_alias_global_variable_node(node)

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -460,7 +460,9 @@ class Phlex::SGML
 	end
 
 	private def __render_attributes__(attributes)
-		@_state.buffer << (Phlex::ATTRIBUTE_CACHE[attributes] ||= Phlex::SGML::Attributes.generate_attributes(attributes))
+		state = @_state
+		return unless state.should_render?
+		state.buffer << (Phlex::ATTRIBUTE_CACHE[attributes] ||= Phlex::SGML::Attributes.generate_attributes(attributes))
 	end
 
 	private_class_method def self.method_added(method_name)

--- a/quickdraw/fixtures/standard_element_example.rb
+++ b/quickdraw/fixtures/standard_element_example.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class ExampleComponent < Phlex::HTML
+	def view_template(&)
+		div(&)
+	end
+end
+
+class StandardElementExample < Phlex::HTML
+	def initialize(execution_checker = -> {})
+		@execution_checker = execution_checker
+	end
+
+	def view_template
+		doctype
+		div {
+			comment { h1(id: "target") }
+			h1 { "Before" }
+			img(src: "before.jpg")
+			render ExampleComponent.new { "Should not render" }
+			whitespace
+			comment { "This is a comment" }
+			fragment("target") do
+				h1(id: "target") {
+					plain "Hello"
+					strong { "World" }
+					img(src: "image.jpg")
+				}
+			end
+			@execution_checker.call
+			strong { "Here" }
+			fragment("image") do
+				img(id: "image", src: "after.jpg")
+			end
+			h1(id: "target") { "After" }
+		}
+	end
+end


### PR DESCRIPTION
Input

```ruby
def view_template
	h1 { "Hello" }
	fragment :name do
		h2 { "World" }
	end
end
```

Output

```ruby
def view_template
	__phlex_state__ = @_state
	__phlex_buffer__ = __phlex_state__.buffer
	__phlex_me__ = self
	__phlex_should_render__ = __phlex_state__.should_render?; nil
	__phlex_buffer__ << "<h1>Hello</h1>" if __phlex_should_render__; nil;
	fragment :name do
		__phlex_original_should_render__ = __phlex_should_render__
		__phlex_should_render__ = __phlex_state__.should_render?;
			__phlex_buffer__ << "<h2>World</h2>" if __phlex_should_render__; nil;
		__phlex_should_render__ = __phlex_original_should_render__
	end
end
```