### PR TITLE
Add `comment` and `raw` to compiler

### DIFF
--- a/lib/phlex/compiler/method_compiler.rb
+++ b/lib/phlex/compiler/method_compiler.rb
@@ -46,6 +46,8 @@ module Phlex::Compiler
 					return compile_plain_helper(node)
 				elsif fragment_helper?(node)
 					return compile_fragment_helper(node)
+				elsif comment_helper?(node)
+					return compile_comment_helper(node)
 				end
 			end
 
@@ -194,6 +196,14 @@ module Phlex::Compiler
 			)
 		end
 
+		def compile_comment_helper(node)
+			[
+				buffer("<!-- "),
+				visit_phlex_block(node.block),
+				buffer(" -->"),
+			]
+		end
+
 		private def ensure_new_line
 			proc(&:ensure_new_line)
 		end
@@ -291,6 +301,10 @@ module Phlex::Compiler
 
 		private def fragment_helper?(node)
 			node.name == :fragment && own_method_without_scope?(node)
+		end
+
+		private def comment_helper?(node)
+			node.name == :comment && own_method_without_scope?(node)
 		end
 
 		ALLOWED_OWNERS = [Phlex::SGML, Phlex::HTML, Phlex::SVG]

--- a/lib/phlex/compiler/method_compiler.rb
+++ b/lib/phlex/compiler/method_compiler.rb
@@ -48,6 +48,8 @@ module Phlex::Compiler
 					return compile_fragment_helper(node)
 				elsif comment_helper?(node)
 					return compile_comment_helper(node)
+				elsif raw_helper?(node)
+					return compile_raw_helper(node)
 				end
 			end
 
@@ -204,6 +206,11 @@ module Phlex::Compiler
 			]
 		end
 
+		def compile_raw_helper(node)
+			@current_buffer = nil
+			node
+		end
+
 		private def ensure_new_line
 			proc(&:ensure_new_line)
 		end
@@ -305,6 +312,10 @@ module Phlex::Compiler
 
 		private def comment_helper?(node)
 			node.name == :comment && own_method_without_scope?(node)
+		end
+
+		private def raw_helper?(node)
+			node.name == :raw && own_method_without_scope?(node)
 		end
 
 		ALLOWED_OWNERS = [Phlex::SGML, Phlex::HTML, Phlex::SVG]

--- a/quickdraw/compilation_equivalence_cases/comment.rb
+++ b/quickdraw/compilation_equivalence_cases/comment.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Comment < Phlex::HTML
+	def view_template
+		comment { "hello world" }
+		comment { "Begin rendering #{self.class.name}" }
+	end
+end

--- a/quickdraw/compilation_equivalence_cases/raw.rb
+++ b/quickdraw/compilation_equivalence_cases/raw.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Raw < Phlex::HTML
+	def view_template
+		p { "output before" }
+		raw(safe("raw output in the middle"))
+		p { "output after" }
+	end
+end


### PR DESCRIPTION
I didn't think there was really any optimization to be done to `raw` but it needs to split the buffer when it's encountered.