### PR TITLE
Fix Kit rendering context error when render? is false

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -60,30 +60,32 @@ class Phlex::SGML
 
 		block ||= @_content_block
 
-		previous_phlex_component = Thread.current[:__phlex_component__]
-		Thread.current[:__phlex_component__] = self
+		begin
+			previous_phlex_component = Thread.current[:__phlex_component__]
+			Thread.current[:__phlex_component__] = self
 
-		state.around_render(self) do
-			before_template(&block)
+			state.around_render(self) do
+				before_template(&block)
 
-			around_template do
-				if block
-					view_template do |*args|
-						if args.length > 0
-							__yield_content_with_args__(*args, &block)
-						else
-							__yield_content__(&block)
+				around_template do
+					if block
+						view_template do |*args|
+							if args.length > 0
+								__yield_content_with_args__(*args, &block)
+							else
+								__yield_content__(&block)
+							end
 						end
+					else
+						view_template
 					end
-				else
-					view_template
 				end
-			end
 
-			after_template(&block)
+				after_template(&block)
+			end
+		ensure
+			Thread.current[:__phlex_component__] = previous_phlex_component
 		end
-	ensure
-		Thread.current[:__phlex_component__] = previous_phlex_component
 	end
 
 	def context

--- a/quickdraw/kit.test.rb
+++ b/quickdraw/kit.test.rb
@@ -14,6 +14,32 @@ class KitTest < Quickdraw::Test
 		end
 	end
 
+	class Components::Title < Phlex::HTML
+		def view_template
+			h1 { "Hello, world" }
+		end
+
+		def render?
+			false
+		end
+	end
+
+	class Components::Subtitle < Phlex::HTML
+		def view_template
+			h2 { "Welcome" }
+		end
+	end
+
+	class Page < Phlex::HTML
+		include Components
+
+		def view_template
+			Components::Title()
+
+			Components::Subtitle()
+		end
+	end
+
 	test "raises when you try to render a component outside of a rendering context" do
 		error = assert_raises(RuntimeError) { Components::SayHi("Joel") }
 		assert_equal error.message, "You can't call `SayHi' outside of a Phlex rendering context."
@@ -25,5 +51,10 @@ class KitTest < Quickdraw::Test
 
 	test "nested kits" do
 		assert_equal phlex { Components::Foo::Bar() }, "<h1>Bar</h1>"
+	end
+
+	# Github issue: https://github.com/yippee-fun/phlex/issues/979
+	test "phlex rendering context" do
+		assert_equal Page.call, %(<h2>Welcome</h2>)
 	end
 end


### PR DESCRIPTION
Fix #979 

I've just moved the `ensure` to wrap the code where Thread.current is modified. 
eg.
```ruby
# BEFORE
def internal_call(...)
  ...
  code
ensure
  ...
end

# AFTER
def internal_call(...)
  ...
  begin
    code
  ensure
    ...
  end
end
```

I could just move the `previous_phlex_component = Thread.current[:__phlex_component__]` to before the `return "" unless render?`  too, but I think this code is clearer.