### PR TITLE
Require 'date' so attribute serialization works without Rails

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "date"
 require "erb"
 require "set"
 require "zeitwerk"

--- a/quickdraw/load.test.rb
+++ b/quickdraw/load.test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class LoadTest < Quickdraw::Test
+	test "requiring phlex makes Date available" do
+		script = <<~RUBY
+			require "phlex"
+
+			Phlex::SGML::Attributes
+			print defined?(Date)
+		RUBY
+
+		output = IO.popen([RbConfig.ruby, "-e", script], err: [:child, :out], &:read)
+		assert_equal $?.exitstatus, 0
+		assert_equal output, "constant"
+	end
+end


### PR DESCRIPTION
Fixes #974

If you use Phlex outside of Rails, rendering attributes can blow up with `NameError: uninitialized constant Phlex::SGML::Attributes::Date`. The attribute serializer has a `case/when Date` branch, but `Date` lives in the stdlib and isn't loaded automatically. Rails apps don't hit this because ActiveSupport pulls in `date` early.

I added `require "date"` to `lib/phlex.rb`, next to the existing `require "set"`. Same convention: `Set` is also used inside `attributes.rb` and required at the top level.

The regression test in `quickdraw/load.test.rb` runs in a subprocess on purpose. Nokogiri is in the test bundle and ends up loading `date`, so checking inline would always pass and wouldn't actually catch this bug coming back.