### PR TITLE
Fix Ruby 4.0 warning in default before_template and after_template

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -326,11 +326,11 @@ class Phlex::SGML
 		nil
 	end
 
-	private def before_template
+	private def before_template(&)
 		nil
 	end
 
-	private def after_template
+	private def after_template(&)
 		nil
 	end
 

--- a/quickdraw/sgml/callbacks.test.rb
+++ b/quickdraw/sgml/callbacks.test.rb
@@ -30,4 +30,9 @@ class CallbacksTest < Quickdraw::Test
 	test "callbacks are called in the correct order" do
 		assert_equal Example.call, "<i>1</i><i>2</i><i>3</i><i>4</i><i>5</i><i>6</i><i>7</i>"
 	end
+
+	test "default before_template and after_template accept a block" do
+		klass = Class.new(Phlex::HTML) { def view_template = span { "hello" } }
+		assert_equal klass.call { "ignored" }, "<span>hello</span>"
+	end
 end


### PR DESCRIPTION
Fixes #985

`SGML#call` passes the caller's block to `before_template` and `after_template` via `&block`, but the default no-op implementations had no block parameter. Ruby 4.0 warns about this:
```
warning: the block passed to 'before_template' may be ignored
warning: the block passed to 'after_template' may be ignored
```
I added `(&)` to both signatures so they accept the block without binding it to a variable. Subclasses that override these methods won't be affected.